### PR TITLE
Updated README.md, fixing the opts parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add Pikaday javascript and css files, e.g.: add `"pikaday-time": "latest"` to yo
 Specify "datetimepicker" for the `type` attribute of any input and set teh SimpleSchema to be an object:
 
 ```html
-{{> afQuickField name="dueDate" type="datetimepicker" opts="optsDatetimepicker"}}
+{{> afQuickField name="dueDate" type="datetimepicker" opts=optsDatetimepicker}}
 ```
 
 In the schema, which will then work with a `quickForm` or `afQuickFields`:


### PR DESCRIPTION
The documentation was encapsulating the opts in double-quotes, which after some debugging, I found it was the root cause of the plugin not working for me.